### PR TITLE
MAP-5: Optimize metadata mapping queries by adding database indices

### DIFF
--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -195,5 +195,61 @@
 							 tableName="metadatamapping_metadata_source"
 							 columnNames="name" />
 	</changeSet>
+	
+	<changeSet id="metadatamapping-2016-02-07-1310-a" author="kosmik">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<indexExists indexName="metadatamapping_idx_mdtm_retired" />
+			</not>
+		</preConditions>
+		<comment>
+			Add index on metadata term mapping retired
+		</comment>
+		<createIndex tableName="metadatamapping_metadata_term_mapping" indexName="metadatamapping_idx_mdtm_retired">
+			<column name="retired" />
+		</createIndex>
+	</changeSet>
+	
+	<changeSet id="metadatamapping-2016-02-07-1310-b" author="kosmik">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<indexExists indexName="metadatamapping_idx_mdtm_mdclass" />
+			</not>
+		</preConditions>
+		<comment>
+			Add index on metadata term mapping metadata class
+		</comment>
+		<createIndex tableName="metadatamapping_metadata_term_mapping" indexName="metadatamapping_idx_mdtm_mdclass">
+			<column name="metadata_class" />
+		</createIndex>
+	</changeSet>
+	
+	<changeSet id="metadatamapping-2016-02-07-1310-c" author="kosmik">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<indexExists indexName="metadatamapping_idx_mdtm_mdsource" />
+			</not>
+		</preConditions>
+		<comment>
+			Add index on metadata term mapping source
+		</comment>
+		<createIndex tableName="metadatamapping_metadata_term_mapping" indexName="metadatamapping_idx_mdtm_mdsource">
+			<column name="metadata_source_id" />
+		</createIndex>
+	</changeSet>
+	
+	<changeSet id="metadatamapping-2016-02-07-1310-d" author="kosmik">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<indexExists indexName="metadatamapping_idx_mdtm_code" />
+			</not>
+		</preConditions>
+		<comment>
+			Add index on metadata term mapping code
+		</comment>
+		<createIndex tableName="metadatamapping_metadata_term_mapping" indexName="metadatamapping_idx_mdtm_code">
+			<column name="code" />
+		</createIndex>
+	</changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
Add indexes on those metadatamapping_metadata_term_mapping columns
that are used in queries and did not have indexes yet. Note that
some indexes already exist prior to this commit (namely the unique
indexes).

Also note that based on testing, mysql allows char values longer
than the 255 char limit (imposed by innodb) to be indexed.
Querying with a char value longer than 255 chars results in the
index as being used as a prefix index.