### PR TITLE
MAP-23 make date_changed optional

### DIFF
--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -312,4 +312,22 @@
 		</delete>
 	</changeSet>
 
+	<changeSet id="metadatamapping-2016-08-03-1044" author="adamgrzybkowski">
+		<preConditions onFail="MARK_RAN">
+			<columnExists tableName="metadatamapping_metadata_source"
+						  columnName="date_changed" />
+			<columnExists tableName="metadatamapping_metadata_term_mapping"
+						  columnName="date_changed" />
+		</preConditions>
+		<comment>
+			Make date_changed optional 
+		</comment>
+		<dropNotNullConstraint tableName="metadatamapping_metadata_term_mapping"
+							   columnName="date_changed"
+							   columnDataType="datetime"/>
+		<dropNotNullConstraint tableName="metadatamapping_metadata_source"
+							   columnName="date_changed"
+							   columnDataType="datetime"/>
+	</changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Currently there is no option to add new Metadata Source or Term Mapping via REST because data_changed cannot be null. This PR change date_changed to optional in both tables.