### PR TITLE
MAP-24 removed mappedObject from rest resource and MetadataReference class

### DIFF
--- a/api/src/main/java/org/openmrs/module/metadatamapping/MetadataTermMapping.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/MetadataTermMapping.java
@@ -14,7 +14,6 @@
 package org.openmrs.module.metadatamapping;
 
 import org.openmrs.BaseOpenmrsMetadata;
-import org.openmrs.OpenmrsMetadata;
 import org.openmrs.module.metadatamapping.util.ArgUtil;
 
 /**
@@ -23,43 +22,6 @@ import org.openmrs.module.metadatamapping.util.ArgUtil;
  * @since 1.1
  */
 public class MetadataTermMapping extends BaseOpenmrsMetadata {
-	
-	/**
-	 * Reference to a metadata object, i.e. a tuple of a canonical class name and a uuid.
-	 * @since 1.2
-	 */
-	public static class MetadataReference {
-		
-		private String referenceCanonicalClassName;
-		
-		private String referenceUuid;
-		
-		/**
-		 * Construct a new reference.
-		 * @param referenceCanonicalClassName canonical class name of referred object
-		 * @param referenceUuid uuid of referred object
-		 */
-		public MetadataReference(String referenceCanonicalClassName, String referenceUuid) {
-			ArgUtil.notNull(referenceCanonicalClassName, "metadataClass");
-			ArgUtil.notNull(referenceUuid, "metadataUuid");
-			this.referenceCanonicalClassName = referenceCanonicalClassName;
-			this.referenceUuid = referenceUuid;
-		}
-		
-		/**
-		 * @return canonical class name of referred object
-		 */
-		public String getReferenceCanonicalClassName() {
-			return referenceCanonicalClassName;
-		}
-		
-		/**
-		 * @return uuid of referred object
-		 */
-		public String getReferenceUuid() {
-			return referenceUuid;
-		}
-	}
 	
 	private Integer metadataTermMappingId;
 	
@@ -82,30 +44,38 @@ public class MetadataTermMapping extends BaseOpenmrsMetadata {
 	 * Construct a new metadata term mapping.
 	 * @param metadataSource defines the namespace of this term, may not be null
 	 * @param metadataTermCode code of this term within metadataSource, may not be null
-	 * @param referredObject object this term maps to, may not be null, must have {@link OpenmrsMetadata#getUuid()}
+	 * @param metadataClass class of mapped object
+	 * @param metadataUuid uuid of mapped object
 	 * @since 1.1
 	 */
-	public MetadataTermMapping(MetadataSource metadataSource, String metadataTermCode, OpenmrsMetadata referredObject) {
+	public MetadataTermMapping(MetadataSource metadataSource, String metadataTermCode, String metadataClass,
+	    String metadataUuid) {
 		this();
 		ArgUtil.notNull(metadataSource, "metadataSource");
 		ArgUtil.notNull(metadataTermCode, "metadataTermCode");
+		ArgUtil.notNull(metadataClass, "metadataClass");
+		ArgUtil.notNull(metadataUuid, "metadataUuid");
 		setMetadataSource(metadataSource);
 		setCode(metadataTermCode);
-		setMappedObject(referredObject);
+		setMetadataClass(metadataClass);
+		setMetadataUuid(metadataUuid);
 	}
 	
 	/**
 	 * Construct a new metadata term mapping without reference to an OpenmrsMetadata object.
 	 * @param metadataSource defines the namespace of this term, may not be null
 	 * @param metadataTermCode code of this term within metadataSource, may not be null
+	 * @param metadataClass class of mapped object
 	 * @since 1.1
 	 */
-	public MetadataTermMapping(MetadataSource metadataSource, String metadataTermCode) {
+	public MetadataTermMapping(MetadataSource metadataSource, String metadataTermCode, String metadataClass) {
 		this();
 		ArgUtil.notNull(metadataSource, "metadataSource");
 		ArgUtil.notNull(metadataTermCode, "metadataTermCode");
+		ArgUtil.notNull(metadataClass, "metadataClass");
 		setMetadataSource(metadataSource);
 		setCode(metadataTermCode);
+		setMetadataClass(metadataClass);
 	}
 	
 	/**
@@ -172,52 +142,32 @@ public class MetadataTermMapping extends BaseOpenmrsMetadata {
 	}
 	
 	/**
-	 * @return canonical class name of the mapped object
+	 * @return metadataClass of mapped object, is never null
 	 */
 	public String getMetadataClass() {
 		return metadataClass;
 	}
 	
 	/**
-	 * @return universally unique id of the mapped object
+	 * @return metadataUuid of mapped object
 	 */
 	public String getMetadataUuid() {
 		return metadataUuid;
 	}
 	
 	/**
-	 * @param mappedObject metadata object this term maps to, may not be null, must have {@link 
-	 * OpenmrsMetadata#getUuid()}
+	 *
+	 * @param metadataClass, reference class of mapped object, may not be null
 	 */
-	public void setMappedObject(OpenmrsMetadata mappedObject) {
-		ArgUtil.notNull(mappedObject, "mappedObject");
-		ArgUtil.notNull(mappedObject.getUuid(), "mappedObject.uuid");
-		setMetadataClass(mappedObject.getClass().getCanonicalName());
-		setMetadataUuid(mappedObject.getUuid());
-	}
-	
-	/**
-	 * @param mappedObjectReference metadata object this term maps to, may not be null
-	 */
-	public void setMappedObject(MetadataReference mappedObjectReference) {
-		ArgUtil.notNull(mappedObjectReference, "mappedObject");
-		setMetadataClass(mappedObjectReference.getReferenceCanonicalClassName());
-		setMetadataUuid(mappedObjectReference.getReferenceUuid());
-	}
-	
-	/**
-	 * Private as we prefer the convenience method {@link #setMappedObject(OpenmrsMetadata)}
-	 * @param metadataClass canonical class name of the mapped object
-	 */
-	private void setMetadataClass(String metadataClass) {
+	public void setMetadataClass(String metadataClass) {
 		this.metadataClass = metadataClass;
 	}
 	
 	/**
-	 * Private as we prefer the convenience method {@link #setMappedObject(OpenmrsMetadata)}
-	 * @param metadataUuid uuid of the mapped object
+	 *
+	 * @param metadataUuid, reference uuid of mapped object
 	 */
-	private void setMetadataUuid(String metadataUuid) {
+	public void setMetadataUuid(String metadataUuid) {
 		this.metadataUuid = metadataUuid;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/MetadataTermMappingSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/MetadataTermMappingSearchCriteria.java
@@ -2,7 +2,6 @@ package org.openmrs.module.metadatamapping.api;
 
 import org.openmrs.OpenmrsMetadata;
 import org.openmrs.module.metadatamapping.MetadataSource;
-import org.openmrs.module.metadatamapping.MetadataTermMapping.MetadataReference;
 
 /**
  * Search criteria for {@link MetadataMappingService#getMetadataTermMappings(MetadataTermMappingSearchCriteria)}. Use the
@@ -17,9 +16,11 @@ public class MetadataTermMappingSearchCriteria extends MetadataSearchCriteria {
 	
 	private String metadataTermName;
 	
-	private OpenmrsMetadata referredObject;
+	private String metadataUuid;
 	
-	private MetadataReference referredObjectReference;
+	private String metadataClass;
+	
+	private OpenmrsMetadata referredObject;
 	
 	/**
 	 * Prefer using {@link MetadataTermMappingSearchCriteriaBuilder} instead. Every parameter is optional.
@@ -48,16 +49,18 @@ public class MetadataTermMappingSearchCriteria extends MetadataSearchCriteria {
 	 * @param metadataSource only get term mappings from this source
 	 * @param metadataTermCode only get term mappings with this code
 	 * @param metadataTermName only get a term mapping with this name (note that names are unique)
-	 * @param referredObjectReference only get term mappings that refer to this metadata object
+	 * @param metadataClass only get term mapping with this metadataClass
+	 * @param metadataUuid only get term mapping with this metadatauuid
 	 */
 	public MetadataTermMappingSearchCriteria(boolean includeAll, Integer firstResult, Integer maxResults,
-	    MetadataSource metadataSource, String metadataTermCode, String metadataTermName,
-	    MetadataReference referredObjectReference) {
+	    MetadataSource metadataSource, String metadataTermCode, String metadataTermName, String metadataClass,
+	    String metadataUuid) {
 		super(includeAll, firstResult, maxResults);
 		this.metadataSource = metadataSource;
 		this.metadataTermCode = metadataTermCode;
 		this.metadataTermName = metadataTermName;
-		this.referredObjectReference = referredObjectReference;
+		this.metadataClass = metadataClass;
+		this.metadataUuid = metadataUuid;
 	}
 	
 	/**
@@ -89,9 +92,18 @@ public class MetadataTermMappingSearchCriteria extends MetadataSearchCriteria {
 	}
 	
 	/**
-	 * @return only get term mappings that refer to this metadata object
+	 *
+	 * @return only get term mappings with this metadataUuid
 	 */
-	public MetadataReference getReferredObjectReference() {
-		return referredObjectReference;
+	public String getMetadataUuid() {
+		return metadataUuid;
+	}
+	
+	/**
+	 *
+	 * @return only get term mappings with this metadataClass
+	 */
+	public String getMetadataClass() {
+		return metadataClass;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/MetadataTermMappingSearchCriteriaBuilder.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/MetadataTermMappingSearchCriteriaBuilder.java
@@ -2,7 +2,6 @@ package org.openmrs.module.metadatamapping.api;
 
 import org.openmrs.OpenmrsMetadata;
 import org.openmrs.module.metadatamapping.MetadataSource;
-import org.openmrs.module.metadatamapping.MetadataTermMapping.MetadataReference;
 
 /**
  * Convenience builder for {@link MetadataTermMappingSearchCriteria}.
@@ -21,9 +20,11 @@ public class MetadataTermMappingSearchCriteriaBuilder {
 	
 	private String metadataTermName;
 	
-	private OpenmrsMetadata referredObject;
+	private String metadataUuid;
 	
-	private MetadataReference referredObjectReference;
+	private String metadataClass;
+	
+	private OpenmrsMetadata referredObject;
 	
 	/**
 	 * @param includeAll include retired term mappings
@@ -84,22 +85,27 @@ public class MetadataTermMappingSearchCriteriaBuilder {
 	 * @return this builder
 	 */
 	public MetadataTermMappingSearchCriteriaBuilder setReferredObject(OpenmrsMetadata referredObject) {
-		if (referredObjectReference != null) {
-			throw new IllegalStateException("referredObject can not be set if referredObjectReference has been set");
-		}
 		this.referredObject = referredObject;
 		return this;
 	}
 	
 	/**
-	 * @param referredObjectReference only get term mappings that refer to this metadata object
+	 *
+	 * @param metadataUuid only get term mappings with this metadataUuid
 	 * @return this builder
 	 */
-	public MetadataTermMappingSearchCriteriaBuilder setReferredObjectReference(MetadataReference referredObjectReference) {
-		if (referredObject != null) {
-			throw new IllegalStateException("referredObjectReference can not be set if referredObject has been set");
-		}
-		this.referredObjectReference = referredObjectReference;
+	public MetadataTermMappingSearchCriteriaBuilder setMetadataUuid(String metadataUuid) {
+		this.metadataUuid = metadataUuid;
+		return this;
+	}
+	
+	/**
+	 *
+	 * @param metadataClass only get term mappings with this metadataClass
+	 * @return this builder
+	 */
+	public MetadataTermMappingSearchCriteriaBuilder setMetadataClass(String metadataClass) {
+		this.metadataClass = metadataClass;
 		return this;
 	}
 	
@@ -112,7 +118,7 @@ public class MetadataTermMappingSearchCriteriaBuilder {
 			        metadataTermCode, metadataTermName, referredObject);
 		} else {
 			return new MetadataTermMappingSearchCriteria(includeAll, firstResult, maxResults, metadataSource,
-			        metadataTermCode, metadataTermName, referredObjectReference);
+			        metadataTermCode, metadataTermName, metadataClass, metadataUuid);
 		}
 	}
 }

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/db/hibernate/HibernateMetadataMappingDAO.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/db/hibernate/HibernateMetadataMappingDAO.java
@@ -147,10 +147,14 @@ public class HibernateMetadataMappingDAO implements MetadataMappingDAO {
 		if (searchCriteria.getReferredObject() != null) {
 			criteria.add(Restrictions.eq("metadataUuid", searchCriteria.getReferredObject().getUuid()));
 			criteria.add(Restrictions.eq("metadataClass", searchCriteria.getReferredObject().getClass().getCanonicalName()));
-		} else if (searchCriteria.getReferredObjectReference() != null) {
-			criteria.add(Restrictions.eq("metadataUuid", searchCriteria.getReferredObjectReference().getReferenceUuid()));
-			criteria.add(Restrictions.eq("metadataClass", searchCriteria.getReferredObjectReference()
-			        .getReferenceCanonicalClassName()));
+		}
+		
+		if (searchCriteria.getMetadataUuid() != null) {
+			criteria.add(Restrictions.eq("metadataUuid", searchCriteria.getMetadataUuid()));
+		}
+		
+		if (searchCriteria.getMetadataClass() != null) {
+			criteria.add(Restrictions.eq("metadataClass", searchCriteria.getMetadataClass()));
 		}
 		
 		if (!searchCriteria.isIncludeAll()) {

--- a/api/src/main/resources/MetadataTermMapping.hbm.xml
+++ b/api/src/main/resources/MetadataTermMapping.hbm.xml
@@ -30,7 +30,7 @@ Copyright (C) OpenMRS, LLC.  All Rights Reserved.
 		<property name="metadataUuid" type="java.lang.String" column="metadata_uuid" length="38" not-null="false" />
 		
 		<!-- BaseOpenmrsMetadata -->
-		<property name="name" type="java.lang.String" column="name" not-null="true" length="255" />
+		<property name="name" type="java.lang.String" column="name" length="255" />
 		<property name="description" type="java.lang.String" column="description" length="1024" />
 		<many-to-one name="creator" class="org.openmrs.User" not-null="true">
 			<column name="creator" />

--- a/api/src/test/java/org/openmrs/module/metadatamapping/api/MetadataMappingServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/metadatamapping/api/MetadataMappingServiceTest.java
@@ -574,10 +574,7 @@ public class MetadataMappingServiceTest extends BaseModuleContextSensitiveTest {
 		MetadataSource metadataSource = new MetadataSource();
 		metadataSource.setName("my-source");
 		
-		Location location = new Location();
-		location.setUuid("some-uuid");
-		
-		MetadataTermMapping metadataTermMapping = new MetadataTermMapping(metadataSource, "my code", location);
+		MetadataTermMapping metadataTermMapping = new MetadataTermMapping(metadataSource, "my code", "org.openmrs.Drug");
 		metadataTermMapping.setName("some term");
 		
 		Assert.assertNull(metadataTermMapping.getId());
@@ -591,15 +588,15 @@ public class MetadataMappingServiceTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	@Test
-	@Verifies(value = "save mapping without a referred object", method = "saveMetadataTermMapping(MetadataTermMapping)")
+	@Verifies(value = "save mapping without metadataUuid", method = "saveMetadataTermMapping(MetadataTermMapping)")
 	public void saveMetadataTermMapping_shouldSaveMappingWithoutReferredObject() {
 		// given
 		MetadataSource metadataSource = new MetadataSource();
 		metadataSource.setName("my-source");
 		
-		MetadataTermMapping metadataTermMapping = new MetadataTermMapping(metadataSource,
-		        "my code without a referred object");
-		metadataTermMapping.setName("some term without a referred object");
+		MetadataTermMapping metadataTermMapping = new MetadataTermMapping(metadataSource, "my code without metadataUuid",
+		        "org.openmrs.Drug");
+		metadataTermMapping.setName("some term without metadataUuid");
 		
 		Assert.assertNull(metadataTermMapping.getId());
 		
@@ -608,7 +605,7 @@ public class MetadataMappingServiceTest extends BaseModuleContextSensitiveTest {
 		
 		// then
 		Assert.assertNotNull(metadataTermMapping.getId());
-		Assert.assertNull(metadataTermMapping.getMetadataClass());
+		Assert.assertNotNull(metadataTermMapping.getMetadataClass());
 		Assert.assertNull(metadataTermMapping.getMetadataUuid());
 	}
 	

--- a/omod/src/main/java/org/openmrs/module/metadatamapping/web/rest/MetadataTermMappingResource.java
+++ b/omod/src/main/java/org/openmrs/module/metadatamapping/web/rest/MetadataTermMappingResource.java
@@ -1,23 +1,18 @@
 package org.openmrs.module.metadatamapping.web.rest;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.metadatamapping.MetadataSource;
 import org.openmrs.module.metadatamapping.MetadataTermMapping;
-import org.openmrs.module.metadatamapping.MetadataTermMapping.MetadataReference;
 import org.openmrs.module.metadatamapping.api.MetadataMappingService;
 import org.openmrs.module.metadatamapping.api.MetadataTermMappingSearchCriteriaBuilder;
 import org.openmrs.module.metadatamapping.web.controller.MetadataMappingRestController;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
-import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
-import org.openmrs.module.webservices.rest.web.annotation.PropertySetter;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
 import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
@@ -39,9 +34,9 @@ public class MetadataTermMappingResource extends MetadataDelegatingCrudResource<
 	
 	public static final String PARAM_SOURCE_NAME_OR_UUID = "source";
 	
-	public static final String PARAM_REFERENCE_CLASS = "refClass";
+	public static final String PARAM_METADATA_CLASS = "metadataClass";
 	
-	public static final String PARAM_REFERENCE_UUID = "refUuid";
+	public static final String PARAM_METADATA_UUID = "metadataUuid";
 	
 	@Override
 	public MetadataTermMapping getByUniqueId(String uniqueId) {
@@ -87,8 +82,6 @@ public class MetadataTermMappingResource extends MetadataDelegatingCrudResource<
 			description.addProperty("metadataClass");
 			description.addProperty("metadataUuid");
 			
-			description.addProperty("mappedObject");
-			
 			// links
 			description.addSelfLink();
 			if (rep instanceof DefaultRepresentation) {
@@ -102,38 +95,17 @@ public class MetadataTermMappingResource extends MetadataDelegatingCrudResource<
 		return description;
 	}
 	
-	@PropertyGetter("mappedObject")
-	public SimpleObject getMappedObject(MetadataTermMapping delegate) {
-		SimpleObject simpleObject = null;
-		if (delegate.getMetadataClass() != null && delegate.getMetadataUuid() != null) {
-			simpleObject = new SimpleObject();
-			simpleObject.put("className", delegate.getMetadataClass());
-			simpleObject.put("uuid", delegate.getMetadataUuid());
-		}
-		
-		return simpleObject;
-	}
-	
-	@PropertySetter("mappedObject")
-	public void setMappedObject(MetadataTermMapping delegate, Object value) throws IllegalAccessException,
-	        NoSuchMethodException, InvocationTargetException {
-		String metadataClass = (String) PropertyUtils.getProperty(value, "className");
-		String metadataUuid = (String) PropertyUtils.getProperty(value, "uuid");
-		MetadataTermMapping.MetadataReference mappedObjectReference = new MetadataTermMapping.MetadataReference(
-		        metadataClass, metadataUuid);
-		delegate.setMappedObject(mappedObjectReference);
-	}
-	
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
 		
 		description.addRequiredProperty("code");
 		description.addRequiredProperty("metadataSource");
-		description.addRequiredProperty("name");
+		description.addRequiredProperty("metadataClass");
 		
+		description.addProperty("name");
 		description.addProperty("description");
-		description.addProperty("mappedObject");
+		description.addProperty("metadataUuid");
 		
 		return description;
 	}
@@ -144,8 +116,9 @@ public class MetadataTermMappingResource extends MetadataDelegatingCrudResource<
 		
 		description.addProperty("code");
 		description.addProperty("description");
-		description.addProperty("mappedObject");
 		description.addProperty("name");
+		description.addProperty("metadataUuid");
+		description.addProperty("metadataClass");
 		
 		return description;
 	}
@@ -192,11 +165,14 @@ public class MetadataTermMappingResource extends MetadataDelegatingCrudResource<
 			searchCriteriaBuilder.setMetadataTermName(metadataTermName);
 		}
 		
-		String referredObjectClassName = context.getParameter(PARAM_REFERENCE_CLASS);
-		String referredObjectUuid = context.getParameter(PARAM_REFERENCE_UUID);
-		if (StringUtils.isNotBlank(referredObjectClassName) && StringUtils.isNotBlank(referredObjectUuid)) {
-			searchCriteriaBuilder.setReferredObjectReference(new MetadataReference(referredObjectClassName.trim(),
-			        referredObjectUuid.trim()));
+		String metadataClassName = context.getParameter(PARAM_METADATA_CLASS);
+		if (StringUtils.isNotBlank(metadataClassName)) {
+			searchCriteriaBuilder.setMetadataClass(metadataClassName);
+		}
+		
+		String metadataUuid = context.getParameter(PARAM_METADATA_UUID);
+		if (StringUtils.isNotBlank(metadataUuid)) {
+			searchCriteriaBuilder.setMetadataUuid(metadataUuid);
 		}
 		
 		Integer firstResult = context.getStartIndex();

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -456,4 +456,17 @@
 		<!-- /constraints for OpenMRSMetadata -->
 	</changeSet>
 
+	<changeSet id="metadatamapping-2016-08-05-8000" author="adamgrzybkowski">
+	<preConditions onFail="MARK_RAN">
+		<columnExists tableName="metadatamapping_metadata_term_mapping"
+					  columnName="name" />
+	</preConditions>
+	<comment>
+		Make name optional
+	</comment>
+	<dropNotNullConstraint tableName="metadatamapping_metadata_term_mapping"
+						   columnName="name"
+						   columnDataType="varchar(255)"/>
+	</changeSet>
+
 </databaseChangeLog>

--- a/omod/src/test/java/org/openmrs/module/metadatamapping/web/rest/MetadataTermMappingResourceOperationTest.java
+++ b/omod/src/test/java/org/openmrs/module/metadatamapping/web/rest/MetadataTermMappingResourceOperationTest.java
@@ -36,9 +36,8 @@ public class MetadataTermMappingResourceOperationTest extends MainResourceContro
 	public void create_shouldPersist() throws Exception {
 		// given
 		SimpleObject postData = new SimpleObject().add("code", "term-123").add("name", "Test Term Mapping 123").add(
-		    "metadataSource", "df29a160-0add-4598-8ac2-b11a9eb3cdb8");
-		postData.add("mappedObject", new SimpleObject().add("className", "org.openmrs.Drug").add("uuid",
-		    "3cfcf118-931c-46f7-8ff6-7b876f0d4202"));
+		    "metadataSource", "df29a160-0add-4598-8ac2-b11a9eb3cdb8").add("metadataClass", "org.openmrs.Drug").add(
+		    "metadataUuid", "3cfcf118-931c-46f7-8ff6-7b876f0d4202");
 		
 		// when
 		SimpleObject postResponseData = deserialize(handle(newPostRequest(getURI(), postData)));
@@ -52,20 +51,18 @@ public class MetadataTermMappingResourceOperationTest extends MainResourceContro
 		assertNotNull(getResponseData);
 		assertEquals("term-123", PropertyUtils.getProperty(getResponseData, "code"));
 		assertEquals("Test Term Mapping 123", PropertyUtils.getProperty(getResponseData, "name"));
+		assertEquals("org.openmrs.Drug", PropertyUtils.getProperty(getResponseData, "metadataClass"));
+		assertEquals("3cfcf118-931c-46f7-8ff6-7b876f0d4202", PropertyUtils.getProperty(getResponseData, "metadataUuid"));
 		Object metadataSource = getResponseData.get("metadataSource");
 		assertEquals("df29a160-0add-4598-8ac2-b11a9eb3cdb8", PropertyUtils.getProperty(metadataSource, "uuid"));
 		
-		Object mappedObject = getResponseData.get("mappedObject");
-		assertEquals("org.openmrs.Drug", PropertyUtils.getProperty(mappedObject, "className"));
-		assertEquals("3cfcf118-931c-46f7-8ff6-7b876f0d4202", PropertyUtils.getProperty(mappedObject, "uuid"));
 	}
 	
 	@Test
 	public void update_shouldPersist() throws Exception {
 		// given
 		SimpleObject postData = new SimpleObject().add("description", "This is the new term mapping description").add(
-		    "mappedObject",
-		    new SimpleObject().add("className", "org.openmrs.Drug").add("uuid", "3cfcf118-931c-46f7-8ff6-7b876f0d4202"));
+		    "metadataClass", "org.openmrs.Drug").add("metadataUuid", "3cfcf118-931c-46f7-8ff6-7b876f0d4202");
 		
 		// when
 		MockHttpServletResponse postResponse = handle(newPostRequest(getURI() + "/" + getUuid(), postData));
@@ -76,10 +73,8 @@ public class MetadataTermMappingResourceOperationTest extends MainResourceContro
 		SimpleObject getResponseData = deserialize(handle(newGetRequest(getURI() + "/" + getUuid())));
 		assertNotNull(getResponseData);
 		assertEquals("This is the new term mapping description", PropertyUtils.getProperty(getResponseData, "description"));
-		
-		Object mappedObject = getResponseData.get("mappedObject");
-		assertEquals("org.openmrs.Drug", PropertyUtils.getProperty(mappedObject, "className"));
-		assertEquals("3cfcf118-931c-46f7-8ff6-7b876f0d4202", PropertyUtils.getProperty(mappedObject, "uuid"));
+		assertEquals("org.openmrs.Drug", PropertyUtils.getProperty(getResponseData, "metadataClass"));
+		assertEquals("3cfcf118-931c-46f7-8ff6-7b876f0d4202", PropertyUtils.getProperty(getResponseData, "metadataUuid"));
 	}
 	
 	@Test
@@ -185,8 +180,8 @@ public class MetadataTermMappingResourceOperationTest extends MainResourceContro
 		
 		// given
 		Location neverNeverLand = locationService.getLocationByUuid("167ce20c-4785-4285-9119-d197268f7f4a");
-		request.setParameter("refUuid", neverNeverLand.getUuid());
-		request.setParameter("refClass", neverNeverLand.getClass().getCanonicalName());
+		request.setParameter("metadataUuid", neverNeverLand.getUuid());
+		request.setParameter("metadataClass", neverNeverLand.getClass().getCanonicalName());
 		request.setParameter(RestConstants.REQUEST_PROPERTY_FOR_INCLUDE_ALL, String.valueOf(false));
 		request.setParameter("startIndex", "0");
 		request.removeParameter("limit");

--- a/omod/src/test/java/org/openmrs/module/metadatamapping/web/rest/MetadataTermMappingResourceRepresentationTest.java
+++ b/omod/src/test/java/org/openmrs/module/metadatamapping/web/rest/MetadataTermMappingResourceRepresentationTest.java
@@ -63,10 +63,6 @@ public class MetadataTermMappingResourceRepresentationTest extends BaseDelegatin
 		assertEquals(getObject().getMetadataSource().getUuid(), metadataSource.get("uuid"));
 		assertEquals(getObject().getMetadataSource().getName(), metadataSource.get("display"));
 		
-		SimpleObject mappedObject = getRepresentation().get("mappedObject");
-		assertEquals(getObject().getMetadataClass(), mappedObject.get("className"));
-		assertEquals(getObject().getMetadataUuid(), mappedObject.get("uuid"));
-		
 		assertPropEquals("code", getObject().getCode());
 		assertPropEquals("metadataClass", getObject().getMetadataClass());
 		assertPropEquals("metadataUuid", getObject().getMetadataUuid());


### PR DESCRIPTION
This PR changes:
- MetadataTermMappingResource body (removed redundant mappedObject, name is optional, metadataClass is required)
- MetadataTermMapping.class (removed MetadataReference)