### PR TITLE
MAP-19 Java API fixes

### DIFF
--- a/api/src/main/java/org/openmrs/module/metadatamapping/MetadataTermMapping.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/MetadataTermMapping.java
@@ -14,6 +14,7 @@
 package org.openmrs.module.metadatamapping;
 
 import org.openmrs.BaseOpenmrsMetadata;
+import org.openmrs.OpenmrsMetadata;
 import org.openmrs.module.metadatamapping.util.ArgUtil;
 
 /**
@@ -38,6 +39,22 @@ public class MetadataTermMapping extends BaseOpenmrsMetadata {
 	 * @see #MetadataTermMapping(MetadataSource, String, OpenmrsMetadata)
 	 */
 	public MetadataTermMapping() {
+	}
+	
+	/**
+	 * Construct a new metadata term mapping.
+	 * @param metadataSource defines the namespace of this term, may not be null
+	 * @param metadataTermCode code of this term within metadataSource, may not be null
+	 * @param mappedObject object to map
+	 * @since 1.1
+	 */
+	public MetadataTermMapping(MetadataSource metadataSource, String metadataTermCode, OpenmrsMetadata mappedObject) {
+		this();
+		ArgUtil.notNull(metadataSource, "metadataSource");
+		ArgUtil.notNull(metadataTermCode, "metadataTermCode");
+		setMetadataSource(metadataSource);
+		setCode(metadataTermCode);
+		setMappedObject(mappedObject);
 	}
 	
 	/**
@@ -169,5 +186,12 @@ public class MetadataTermMapping extends BaseOpenmrsMetadata {
 	 */
 	public void setMetadataUuid(String metadataUuid) {
 		this.metadataUuid = metadataUuid;
+	}
+	
+	public void setMappedObject(OpenmrsMetadata mappedObject) {
+		ArgUtil.notNull(mappedObject, "metadataObject");
+		ArgUtil.notNull(mappedObject.getUuid(), "mappedObject.uuid");
+		setMetadataClass(mappedObject.getClass().getCanonicalName());
+		setMetadataUuid(mappedObject.getUuid());
 	}
 }

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/MetadataMappingService.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/MetadataMappingService.java
@@ -378,6 +378,17 @@ public interface MetadataMappingService {
 	 */
 	@Authorized()
 	MetadataTermMapping getMetadataTermMapping(MetadataSource metadataSource, String metadataTermCode);
+
+	/**
+	 * Get a specific metadata term mapping from a specific source.
+	 * @param metadataSourceName name of source of the term
+	 * @param metadataTermCode code of the term
+	 * @return object or null, if does not exist
+	 * @since 1.2
+	 * @should return a retired term mapping
+	 */
+	@Authorized()
+	MetadataTermMapping getMetadataTermMapping(String metadataSourceName, String metadataTermCode);
 	
 	/**
 	 * Get all unretired metadata term mappings in the source.

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/MetadataMappingService.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/MetadataMappingService.java
@@ -431,6 +431,7 @@ public interface MetadataMappingService {
 	 * @since 1.1
 	 * @should save valid new object
 	 */
+	@Authorized(MetadataMapping.PRIVILEGE_MANAGE)
 	MetadataSet saveMetadataSet(MetadataSet metadataSet);
 	
 	/**
@@ -440,6 +441,7 @@ public interface MetadataMappingService {
 	 * @since 1.2
 	 * @should return a retired set
 	 */
+	@Authorized()
 	MetadataSet getMetadataSet(Integer metadataSetId);
 	
 	/**
@@ -447,6 +449,7 @@ public interface MetadataMappingService {
 	 * @param criteria
 	 * @return
 	 */
+	@Authorized()
 	List<MetadataSet> getMetadataSets(MetadataSetSearchCriteria criteria);
 	
 	/**
@@ -456,6 +459,7 @@ public interface MetadataMappingService {
 	 * @since 1.2
 	 * @should return matching metadata set
 	 */
+	@Authorized()
 	MetadataSet getMetadataSetByUuid(String metadataSetUuid);
 	
 	/**
@@ -467,6 +471,7 @@ public interface MetadataMappingService {
 	 * @should retire and set info
 	 * @should retire members
 	 */
+	@Authorized(MetadataMapping.PRIVILEGE_MANAGE)
 	MetadataSet retireMetadataSet(MetadataSet metadataSet, String reason);
 	
 	/**
@@ -476,6 +481,7 @@ public interface MetadataMappingService {
 	 * @since 1.2
 	 * @see #getMetadataSetMembers(MetadataSet, int, int, RetiredHandlingMode)
 	 */
+	@Authorized(MetadataMapping.PRIVILEGE_MANAGE)
 	MetadataSetMember saveMetadataSetMember(MetadataSetMember metadataSetMember);
 	
 	/**
@@ -486,6 +492,7 @@ public interface MetadataMappingService {
 	 * @since 1.2
 	 * @see #getMetadataSetMembers(MetadataSet, int, int, RetiredHandlingMode)
 	 */
+	@Authorized(MetadataMapping.PRIVILEGE_MANAGE)
 	MetadataSetMember saveMetadataSetMember(MetadataSet metadataSet, OpenmrsMetadata metadata);
 	
 	/**
@@ -495,6 +502,7 @@ public interface MetadataMappingService {
 	 * @since 1.1
 	 * @see #saveMetadataSetMember(MetadataSetMember)
 	 */
+	@Authorized(MetadataMapping.PRIVILEGE_MANAGE)
 	Collection<MetadataSetMember> saveMetadataSetMembers(Collection<MetadataSetMember> metadataSetMembers);
 	
 	/**
@@ -503,6 +511,7 @@ public interface MetadataMappingService {
 	 * @return object or null, if does not exist
 	 * @since 1.2
 	 */
+	@Authorized()
 	MetadataSetMember getMetadataSetMember(Integer metadataSetMemberId);
 	
 	/**
@@ -511,6 +520,7 @@ public interface MetadataMappingService {
 	 * @return object or null, if does not exist
 	 * @since 1.2
 	 */
+	@Authorized()
 	MetadataSetMember getMetadataSetMemberByUuid(String metadataSetMemberUuid);
 	
 	/**
@@ -526,6 +536,7 @@ public interface MetadataMappingService {
 	 * @should get members in desired order 1
 	 * @should respect retire fetch mode 1
 	 */
+	@Authorized()
 	List<MetadataSetMember> getMetadataSetMembers(MetadataSet metadataSet, int firstResult, int maxResults,
 	        RetiredHandlingMode retiredHandlingMode);
 	
@@ -542,6 +553,7 @@ public interface MetadataMappingService {
 	 * @should get members in desired order 1
 	 * @should respect retire fetch mode 1
 	 */
+	@Authorized()
 	List<MetadataSetMember> getMetadataSetMembers(String metadataSetUuid, int firstResult, int maxResults,
 	        RetiredHandlingMode retiredHandlingMode);
 	
@@ -559,9 +571,10 @@ public interface MetadataMappingService {
 	 * @should get unretired metadata items of unretired terms matching type in sort weight order 1
 	 * @should throw IllegalArgumentException if set does not exist
 	 */
+	@Authorized(MetadataMapping.PRIVILEGE_VIEW_METADATA)
 	<T extends OpenmrsMetadata> List<T> getMetadataSetItems(Class<T> type, MetadataSet metadataSet, int firstResult,
 	        int maxResults);
-
+	
 	/**
 	 * Get unretired metadata items in the set of specified type. If set members have {@link MetadataSetMember#getSortWeight()} set they will
 	 * be ordered in ascending order according to said weight. Note that due to differences in database implementations,
@@ -574,6 +587,7 @@ public interface MetadataMappingService {
 	 * @should get unretired metadata items of unretired terms matching type in sort weight order 1
 	 * @should throw IllegalArgumentException if set does not exist
 	 */
+	@Authorized(MetadataMapping.PRIVILEGE_VIEW_METADATA)
 	<T extends OpenmrsMetadata> List<T> getMetadataSetItems(Class<T> type, MetadataSet metadataSet);
 	
 	/**
@@ -588,6 +602,7 @@ public interface MetadataMappingService {
 	 * @should return null for non existent set member
 	 * @since 1.2
 	 */
+	@Authorized(MetadataMapping.PRIVILEGE_VIEW_METADATA)
 	<T extends OpenmrsMetadata> T getMetadataItem(Class<T> type, MetadataSetMember setMember);
 	
 	/**
@@ -598,5 +613,6 @@ public interface MetadataMappingService {
 	 * @since 1.2
 	 * @should retire and set info
 	 */
+	@Authorized(MetadataMapping.PRIVILEGE_MANAGE)
 	MetadataSetMember retireMetadataSetMember(MetadataSetMember metadataSetMember, String reason);
 }

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/MetadataMappingService.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/MetadataMappingService.java
@@ -378,7 +378,7 @@ public interface MetadataMappingService {
 	 */
 	@Authorized()
 	MetadataTermMapping getMetadataTermMapping(MetadataSource metadataSource, String metadataTermCode);
-
+	
 	/**
 	 * Get a specific metadata term mapping from a specific source.
 	 * @param metadataSourceName name of source of the term

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/MetadataMappingService.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/MetadataMappingService.java
@@ -561,6 +561,20 @@ public interface MetadataMappingService {
 	 */
 	<T extends OpenmrsMetadata> List<T> getMetadataSetItems(Class<T> type, MetadataSet metadataSet, int firstResult,
 	        int maxResults);
+
+	/**
+	 * Get unretired metadata items in the set of specified type. If set members have {@link MetadataSetMember#getSortWeight()} set they will
+	 * be ordered in ascending order according to said weight. Note that due to differences in database implementations,
+	 * the order  will be unpredictable, if there are null sort weights in the set.
+	 * @param type type of the metadata items
+	 * @param metadataSet metadata set
+	 * @param <T> type of the metadata items
+	 * @return list of items in the order defined by the optional {@link MetadataSetMember#getSortWeight()} values
+	 * @since 1.2
+	 * @should get unretired metadata items of unretired terms matching type in sort weight order 1
+	 * @should throw IllegalArgumentException if set does not exist
+	 */
+	<T extends OpenmrsMetadata> List<T> getMetadataSetItems(Class<T> type, MetadataSet metadataSet);
 	
 	/**
 	 * Get metadata item referred to by the given metadata term mapping

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/db/MetadataMappingDAO.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/db/MetadataMappingDAO.java
@@ -205,21 +205,32 @@ public interface MetadataMappingDAO {
 	 */
 	List<MetadataSetMember> getMetadataSetMembers(String metadataSetUuid, int firstResult, int maxResults,
 	        RetiredHandlingMode retiredHandlingMode);
-	
+
 	/**
-	 * Get unretired metadata items in the set. If set members have {@link MetadataSetMember#getSortWeight()} set they will 
-	 * be ordered in ascending order according to said weight. Note that due to differences in database implementations, 
+	 * Get unretired metadata items in the set. If set members have {@link MetadataSetMember#getSortWeight()} set they will
+	 * be ordered in ascending order according to said weight. Note that due to differences in database implementations,
 	 * the order  will be unpredictable, if there are null sort weights in the set.
 	 * @param type type of the metadata items
 	 * @param metadataSet metadata set
-	 * @param firstResult zero based index of first result to get 
+	 * @param firstResult zero based index of first result to get
 	 * @param maxResults maximum number of results to get
 	 * @param <T> type of the metadata items
 	 * @return list of items in the order defined by the optional {@link MetadataSetMember#getSortWeight()} values
 	 */
 	<T extends OpenmrsMetadata> List<T> getMetadataSetItems(Class<T> type, MetadataSet metadataSet, int firstResult,
 	        int maxResults);
-	
+
+    /**
+     * Get unretired metadata items in the set. If set members have {@link MetadataSetMember#getSortWeight()} set they will
+     * be ordered in ascending order according to said weight. Note that due to differences in database implementations,
+     * the order  will be unpredictable, if there are null sort weights in the set.
+     * @param type type of the metadata items
+     * @param metadataSet metadata set
+     * @param <T> type of the metadata items
+     * @return list of items in the order defined by the optional {@link MetadataSetMember#getSortWeight()} values
+     */
+    <T extends OpenmrsMetadata> List<T> getMetadataSetItems(Class<T> type, MetadataSet metadataSet);
+
 	/**
 	 * Get metadata sets.
 	 * @param searchCriteria find metadata sets matching these criteria

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/db/MetadataMappingDAO.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/db/MetadataMappingDAO.java
@@ -205,7 +205,7 @@ public interface MetadataMappingDAO {
 	 */
 	List<MetadataSetMember> getMetadataSetMembers(String metadataSetUuid, int firstResult, int maxResults,
 	        RetiredHandlingMode retiredHandlingMode);
-
+	
 	/**
 	 * Get unretired metadata items in the set. If set members have {@link MetadataSetMember#getSortWeight()} set they will
 	 * be ordered in ascending order according to said weight. Note that due to differences in database implementations,
@@ -219,18 +219,18 @@ public interface MetadataMappingDAO {
 	 */
 	<T extends OpenmrsMetadata> List<T> getMetadataSetItems(Class<T> type, MetadataSet metadataSet, int firstResult,
 	        int maxResults);
-
-    /**
-     * Get unretired metadata items in the set. If set members have {@link MetadataSetMember#getSortWeight()} set they will
-     * be ordered in ascending order according to said weight. Note that due to differences in database implementations,
-     * the order  will be unpredictable, if there are null sort weights in the set.
-     * @param type type of the metadata items
-     * @param metadataSet metadata set
-     * @param <T> type of the metadata items
-     * @return list of items in the order defined by the optional {@link MetadataSetMember#getSortWeight()} values
-     */
-    <T extends OpenmrsMetadata> List<T> getMetadataSetItems(Class<T> type, MetadataSet metadataSet);
-
+	
+	/**
+	 * Get unretired metadata items in the set. If set members have {@link MetadataSetMember#getSortWeight()} set they will
+	 * be ordered in ascending order according to said weight. Note that due to differences in database implementations,
+	 * the order  will be unpredictable, if there are null sort weights in the set.
+	 * @param type type of the metadata items
+	 * @param metadataSet metadata set
+	 * @param <T> type of the metadata items
+	 * @return list of items in the order defined by the optional {@link MetadataSetMember#getSortWeight()} values
+	 */
+	<T extends OpenmrsMetadata> List<T> getMetadataSetItems(Class<T> type, MetadataSet metadataSet);
+	
 	/**
 	 * Get metadata sets.
 	 * @param searchCriteria find metadata sets matching these criteria

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/db/hibernate/HibernateMetadataMappingDAO.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/db/hibernate/HibernateMetadataMappingDAO.java
@@ -310,13 +310,13 @@ public class HibernateMetadataMappingDAO implements MetadataMappingDAO {
 	        int maxResults) {
 		return internalGetMetadataSetItems(type, metadataSet, firstResult, maxResults);
 	}
-
-    @Override
-    public <T extends OpenmrsMetadata> List<T> getMetadataSetItems(Class<T> type, MetadataSet metadataSet) {
-        return internalGetMetadataSetItems(type, metadataSet, null, null);
-    }
-
-    private MetadataTermMapping internalSaveMetadataTermMapping(MetadataTermMapping metadataTermMapping) {
+	
+	@Override
+	public <T extends OpenmrsMetadata> List<T> getMetadataSetItems(Class<T> type, MetadataSet metadataSet) {
+		return internalGetMetadataSetItems(type, metadataSet, null, null);
+	}
+	
+	private MetadataTermMapping internalSaveMetadataTermMapping(MetadataTermMapping metadataTermMapping) {
 		getCurrentSession().saveOrUpdate(metadataTermMapping);
 		return metadataTermMapping;
 	}
@@ -387,12 +387,12 @@ public class HibernateMetadataMappingDAO implements MetadataMappingDAO {
 		memberCriteria.add(Subqueries.propertyIn("member.metadataUuid", metadataItemSubQuery));
 		
 		memberCriteria.setProjection(Projections.property("member.metadataUuid"));
-        if(firstResult != null){
-            memberCriteria.setFirstResult(firstResult);
-        }
-        if(maxResults != null){
-            memberCriteria.setMaxResults(maxResults);
-        }
+		if (firstResult != null) {
+			memberCriteria.setFirstResult(firstResult);
+		}
+		if (maxResults != null) {
+			memberCriteria.setMaxResults(maxResults);
+		}
 		memberCriteria.addOrder(Order.desc("member.sortWeight"));
 		
 		List<String> itemUuids = memberCriteria.list();

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/db/hibernate/HibernateMetadataMappingDAO.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/db/hibernate/HibernateMetadataMappingDAO.java
@@ -310,8 +310,13 @@ public class HibernateMetadataMappingDAO implements MetadataMappingDAO {
 	        int maxResults) {
 		return internalGetMetadataSetItems(type, metadataSet, firstResult, maxResults);
 	}
-	
-	private MetadataTermMapping internalSaveMetadataTermMapping(MetadataTermMapping metadataTermMapping) {
+
+    @Override
+    public <T extends OpenmrsMetadata> List<T> getMetadataSetItems(Class<T> type, MetadataSet metadataSet) {
+        return internalGetMetadataSetItems(type, metadataSet, null, null);
+    }
+
+    private MetadataTermMapping internalSaveMetadataTermMapping(MetadataTermMapping metadataTermMapping) {
 		getCurrentSession().saveOrUpdate(metadataTermMapping);
 		return metadataTermMapping;
 	}
@@ -365,7 +370,7 @@ public class HibernateMetadataMappingDAO implements MetadataMappingDAO {
 	}
 	
 	private <T extends OpenmrsMetadata> List<T> internalGetMetadataSetItems(Class<T> type, MetadataSet metadataSet,
-	        int firstResult, int maxResults) {
+	        Integer firstResult, Integer maxResults) {
 		if (metadataSet == null) {
 			throw new IllegalArgumentException("To obtain MetadataSet items, reference to MetadataSet must be given");
 		}
@@ -382,8 +387,12 @@ public class HibernateMetadataMappingDAO implements MetadataMappingDAO {
 		memberCriteria.add(Subqueries.propertyIn("member.metadataUuid", metadataItemSubQuery));
 		
 		memberCriteria.setProjection(Projections.property("member.metadataUuid"));
-		memberCriteria.setFirstResult(firstResult);
-		memberCriteria.setMaxResults(maxResults);
+        if(firstResult != null){
+            memberCriteria.setFirstResult(firstResult);
+        }
+        if(maxResults != null){
+            memberCriteria.setMaxResults(maxResults);
+        }
 		memberCriteria.addOrder(Order.desc("member.sortWeight"));
 		
 		List<String> itemUuids = memberCriteria.list();

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/db/hibernate/HibernateMetadataMappingDAO.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/db/hibernate/HibernateMetadataMappingDAO.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
+import org.hibernate.classic.Session;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
@@ -28,6 +29,9 @@ import org.hibernate.criterion.Subqueries;
 import org.openmrs.Concept;
 import org.openmrs.OpenmrsMetadata;
 import org.openmrs.OpenmrsObject;
+import org.openmrs.api.db.hibernate.DbSession;
+import org.openmrs.api.db.hibernate.DbSessionFactory;
+import org.openmrs.api.db.hibernate.HibernateUtil;
 import org.openmrs.module.metadatamapping.MetadataSet;
 import org.openmrs.module.metadatamapping.MetadataSetMember;
 import org.openmrs.module.metadatamapping.MetadataSource;
@@ -51,8 +55,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class HibernateMetadataMappingDAO implements MetadataMappingDAO {
 	
 	@Autowired
-	@Qualifier("sessionFactory")
-	private SessionFactory sessionFactory;
+	private DbSessionFactory sessionFactory;
+	
+	public DbSession getCurrentSession() {
+		return sessionFactory.getCurrentSession();
+	}
 	
 	/**
 	 * @see MetadataMappingDAO#getConcepts(int, int)
@@ -347,26 +354,6 @@ public class HibernateMetadataMappingDAO implements MetadataMappingDAO {
 		criteria = criteria.createCriteria("metadataSource").add(Restrictions.eq("name", metadataSourceName));
 		
 		return criteria;
-	}
-	
-	/**
-	 * Gets the current hibernate session while taking care of the hibernate 3 and 4 differences.
-	 *
-	 * @return the current hibernate session.
-	 */
-	private org.hibernate.Session getCurrentSession() {
-		try {
-			return sessionFactory.getCurrentSession();
-		}
-		catch (NoSuchMethodError ex) {
-			try {
-				Method method = sessionFactory.getClass().getMethod("getCurrentSession", null);
-				return (org.hibernate.Session) method.invoke(sessionFactory, null);
-			}
-			catch (Exception e) {
-				throw new RuntimeException("Failed to get the current hibernate session", e);
-			}
-		}
 	}
 	
 	private <T extends OpenmrsMetadata> List<T> internalGetMetadataSetItems(Class<T> type, MetadataSet metadataSet,

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/impl/MetadataMappingServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/impl/MetadataMappingServiceImpl.java
@@ -558,6 +558,12 @@ public class MetadataMappingServiceImpl extends BaseOpenmrsService implements Me
 	        int maxResults) {
 		return dao.getMetadataSetItems(type, metadataSet, firstResult, maxResults);
 	}
+
+    @Override
+    @Transactional(readOnly = true)
+    public <T extends OpenmrsMetadata> List<T> getMetadataSetItems(Class<T> type, MetadataSet metadataSet) {
+        return dao.getMetadataSetItems(type, metadataSet);
+    }
 	
 	@Override
 	public <T extends OpenmrsMetadata> T getMetadataItem(Class<T> type, MetadataSetMember setMember) {

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/impl/MetadataMappingServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/impl/MetadataMappingServiceImpl.java
@@ -558,12 +558,12 @@ public class MetadataMappingServiceImpl extends BaseOpenmrsService implements Me
 	        int maxResults) {
 		return dao.getMetadataSetItems(type, metadataSet, firstResult, maxResults);
 	}
-
-    @Override
-    @Transactional(readOnly = true)
-    public <T extends OpenmrsMetadata> List<T> getMetadataSetItems(Class<T> type, MetadataSet metadataSet) {
-        return dao.getMetadataSetItems(type, metadataSet);
-    }
+	
+	@Override
+	@Transactional(readOnly = true)
+	public <T extends OpenmrsMetadata> List<T> getMetadataSetItems(Class<T> type, MetadataSet metadataSet) {
+		return dao.getMetadataSetItems(type, metadataSet);
+	}
 	
 	@Override
 	public <T extends OpenmrsMetadata> T getMetadataItem(Class<T> type, MetadataSetMember setMember) {

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/impl/MetadataMappingServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/impl/MetadataMappingServiceImpl.java
@@ -433,7 +433,12 @@ public class MetadataMappingServiceImpl extends BaseOpenmrsService implements Me
 	public MetadataTermMapping getMetadataTermMapping(MetadataSource metadataSource, String metadataTermCode) {
 		return dao.getMetadataTermMapping(metadataSource, metadataTermCode);
 	}
-	
+
+	@Override
+	public MetadataTermMapping getMetadataTermMapping(String metadataSourceName, String metadataTermCode) {
+		return dao.getMetadataTermMapping(dao.getMetadataSourceByName(metadataSourceName), metadataTermCode);
+	}
+
 	@Override
 	@Transactional(readOnly = true)
 	public List<MetadataTermMapping> getMetadataTermMappings(MetadataSource metadataSource) {

--- a/api/src/main/java/org/openmrs/module/metadatamapping/api/impl/MetadataMappingServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/api/impl/MetadataMappingServiceImpl.java
@@ -433,12 +433,12 @@ public class MetadataMappingServiceImpl extends BaseOpenmrsService implements Me
 	public MetadataTermMapping getMetadataTermMapping(MetadataSource metadataSource, String metadataTermCode) {
 		return dao.getMetadataTermMapping(metadataSource, metadataTermCode);
 	}
-
+	
 	@Override
 	public MetadataTermMapping getMetadataTermMapping(String metadataSourceName, String metadataTermCode) {
 		return dao.getMetadataTermMapping(dao.getMetadataSourceByName(metadataSourceName), metadataTermCode);
 	}
-
+	
 	@Override
 	@Transactional(readOnly = true)
 	public List<MetadataTermMapping> getMetadataTermMappings(MetadataSource metadataSource) {

--- a/api/src/main/java/org/openmrs/module/metadatamapping/util/GlobalPropertyToMappingConverter.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/util/GlobalPropertyToMappingConverter.java
@@ -12,42 +12,51 @@ import java.lang.reflect.Type;
 
 /**
  * Helper for other modules to make migration from GP to mappings easier
+ *
  * @param <T> Class of mapped metadata object
  */
-public abstract class GlobalPropertyToMappingConverter<T extends OpenmrsMetadata>{
-
-    MetadataSource source;
-
-    public GlobalPropertyToMappingConverter(MetadataSource source) {
-        this.source = source;
-    }
-
-    abstract T getMetadataByUuid(String uuid);
-
-    void saveIfMissing(String globalProperty){
-        MetadataMappingService metadataMappingService = Context.getService(MetadataMappingService.class);
-        MetadataTermMapping metadataTermMapping = metadataMappingService.getMetadataTermMapping(source, globalProperty);
-        if(metadataTermMapping == null){
-            T instance = null;
-
-            String globalPropertyValue = Context.getAdministrationService().getGlobalProperty(globalProperty);
-            if(StringUtils.isNotBlank(globalPropertyValue)){
-                instance = getMetadataByUuid(globalPropertyValue);
-            }
-
-            if(instance == null){
-                metadataTermMapping = new MetadataTermMapping(source, globalProperty, getMetadataClass());
-            } else {
-                metadataTermMapping = new MetadataTermMapping(source, globalProperty, instance);
-            }
-            metadataMappingService.saveMetadataTermMapping(metadataTermMapping);
-        }
-    }
-
-    private String getMetadataClass(){
-        Type superclass = getClass().getGenericSuperclass();
-        String typeString = ((ParameterizedType)superclass).getActualTypeArguments()[0].toString();
-        //cut off 'class ' prefix
-        return typeString.substring("class ".length());
-    }
+public abstract class GlobalPropertyToMappingConverter<T extends OpenmrsMetadata> {
+	
+	private MetadataSource source;
+	
+	public GlobalPropertyToMappingConverter(MetadataSource source) {
+		this.source = source;
+	}
+	
+	public abstract T getMetadataByUuid(String uuid);
+	
+	/**
+	 * Creates missing mappings for metadata necessary for module functioning. MetadataTermMapping codes match global properties keys.
+	 * Note that if mapping already has been created, and global property is edited, these changes will not be reflected in module metadata
+	 * @should do nothing, if mapping is not missing
+	 * @should create new mapping without mapped object, if mapping is missing and there is no global property or it has value not matching any OpenmrsMetadata uuid
+	 * @should create new mapping with mapped object, if mapping is missing and there is global property with uuid matching existing OpenmrsMetadata
+	 * @param globalProperty - global property to convert to metadata mapping
+	 */
+	public void convert(String globalProperty) {
+		MetadataMappingService metadataMappingService = Context.getService(MetadataMappingService.class);
+		MetadataTermMapping metadataTermMapping = metadataMappingService.getMetadataTermMapping(source, globalProperty);
+		if (metadataTermMapping == null) {
+			T instance = null;
+			
+			String globalPropertyValue = Context.getAdministrationService().getGlobalProperty(globalProperty);
+			if (StringUtils.isNotBlank(globalPropertyValue)) {
+				instance = getMetadataByUuid(globalPropertyValue);
+			}
+			
+			if (instance == null) {
+				metadataTermMapping = new MetadataTermMapping(source, globalProperty, getMetadataClass());
+			} else {
+				metadataTermMapping = new MetadataTermMapping(source, globalProperty, instance);
+			}
+			metadataMappingService.saveMetadataTermMapping(metadataTermMapping);
+		}
+	}
+	
+	private String getMetadataClass() {
+		Type superclass = getClass().getGenericSuperclass();
+		String typeString = ((ParameterizedType) superclass).getActualTypeArguments()[0].toString();
+		//cut off 'class ' prefix
+		return typeString.substring("class ".length());
+	}
 }

--- a/api/src/main/java/org/openmrs/module/metadatamapping/util/GlobalPropertyToMappingConverter.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/util/GlobalPropertyToMappingConverter.java
@@ -1,0 +1,53 @@
+package org.openmrs.module.metadatamapping.util;
+
+import org.apache.commons.lang.StringUtils;
+import org.openmrs.OpenmrsMetadata;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.metadatamapping.MetadataSource;
+import org.openmrs.module.metadatamapping.MetadataTermMapping;
+import org.openmrs.module.metadatamapping.api.MetadataMappingService;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+/**
+ * Helper for other modules to make migration from GP to mappings easier
+ * @param <T> Class of mapped metadata object
+ */
+public abstract class GlobalPropertyToMappingConverter<T extends OpenmrsMetadata>{
+
+    MetadataSource source;
+
+    public GlobalPropertyToMappingConverter(MetadataSource source) {
+        this.source = source;
+    }
+
+    abstract T getMetadataByUuid(String uuid);
+
+    void saveIfMissing(String globalProperty){
+        MetadataMappingService metadataMappingService = Context.getService(MetadataMappingService.class);
+        MetadataTermMapping metadataTermMapping = metadataMappingService.getMetadataTermMapping(source, globalProperty);
+        if(metadataTermMapping == null){
+            T instance = null;
+
+            String globalPropertyValue = Context.getAdministrationService().getGlobalProperty(globalProperty);
+            if(StringUtils.isNotBlank(globalPropertyValue)){
+                instance = getMetadataByUuid(globalPropertyValue);
+            }
+
+            if(instance == null){
+                metadataTermMapping = new MetadataTermMapping(source, globalProperty, getMetadataClass());
+            } else {
+                metadataTermMapping = new MetadataTermMapping(source, globalProperty, instance);
+            }
+            metadataMappingService.saveMetadataTermMapping(metadataTermMapping);
+        }
+    }
+
+    private String getMetadataClass(){
+        Type superclass = getClass().getGenericSuperclass();
+        String typeString = ((ParameterizedType)superclass).getActualTypeArguments()[0].toString();
+        //cut off 'class ' prefix
+        return typeString.substring("class ".length());
+    }
+}

--- a/api/src/main/java/org/openmrs/module/metadatamapping/util/ModuleProperties.java
+++ b/api/src/main/java/org/openmrs/module/metadatamapping/util/ModuleProperties.java
@@ -1,0 +1,250 @@
+package org.openmrs.module.metadatamapping.util;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.Concept;
+import org.openmrs.ConceptSource;
+import org.openmrs.OpenmrsMetadata;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.EncounterService;
+import org.openmrs.api.FormService;
+import org.openmrs.api.LocationService;
+import org.openmrs.api.OrderService;
+import org.openmrs.api.PatientService;
+import org.openmrs.api.PersonService;
+import org.openmrs.api.ProviderService;
+import org.openmrs.api.UserService;
+import org.openmrs.api.VisitService;
+import org.openmrs.module.metadatamapping.MetadataSet;
+import org.openmrs.module.metadatamapping.MetadataSource;
+import org.openmrs.module.metadatamapping.MetadataTermMapping;
+import org.openmrs.module.metadatamapping.api.MetadataMappingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Helper class that lets modules centralize their configuration details. See EmrProperties for an example.
+ */
+@SuppressWarnings("SpringJavaAutowiringInspection")
+public abstract class ModuleProperties {
+	
+	private static final Log log = LogFactory.getLog(ModuleProperties.class);
+	
+	/**
+	 * services
+	 */
+	@Autowired
+	protected MetadataMappingService metadataMappingService;
+	
+	@Autowired
+	@Qualifier("conceptService")
+	protected ConceptService conceptService;
+	
+	@Autowired
+	@Qualifier("encounterService")
+	protected EncounterService encounterService;
+	
+	@Autowired
+	@Qualifier("visitService")
+	protected VisitService visitService;
+	
+	@Autowired
+	@Qualifier("orderService")
+	protected OrderService orderService;
+	
+	@Autowired
+	@Qualifier("adminService")
+	protected AdministrationService administrationService;
+	
+	@Autowired
+	@Qualifier("locationService")
+	protected LocationService locationService;
+	
+	@Autowired
+	@Qualifier("userService")
+	protected UserService userService;
+	
+	@Autowired
+	@Qualifier("patientService")
+	protected PatientService patientService;
+	
+	@Autowired
+	@Qualifier("personService")
+	protected PersonService personService;
+	
+	@Autowired
+	@Qualifier("providerService")
+	protected ProviderService providerService;
+	
+	@Autowired
+	@Qualifier("formService")
+	protected FormService formService;
+	
+	/**
+	 * setters for easy testing
+	 */
+	public void setMetadataMappingService(MetadataMappingService metadataMappingService) {
+		this.metadataMappingService = metadataMappingService;
+	}
+	
+	public void setConceptService(ConceptService conceptService) {
+		this.conceptService = conceptService;
+	}
+	
+	public void setAdministrationService(AdministrationService administrationService) {
+		this.administrationService = administrationService;
+	}
+	
+	public void setEncounterService(EncounterService encounterService) {
+		this.encounterService = encounterService;
+	}
+	
+	public void setOrderService(OrderService orderService) {
+		this.orderService = orderService;
+	}
+	
+	public void setVisitService(VisitService visitService) {
+		this.visitService = visitService;
+	}
+	
+	public void setLocationService(LocationService locationService) {
+		this.locationService = locationService;
+	}
+	
+	public void setUserService(UserService userService) {
+		this.userService = userService;
+	}
+	
+	public void setPatientService(PatientService patientService) {
+		this.patientService = patientService;
+	}
+	
+	public void setPersonService(PersonService personService) {
+		this.personService = personService;
+	}
+	
+	public void setProviderService(ProviderService providerService) {
+		this.providerService = providerService;
+	}
+	
+	/**
+	 * Module should use single metadata source for all its mappings,
+	 * source name returned by this method will be used to lookup metadata
+	 */
+	public abstract String getMetadataSourceName();
+	
+	protected ConceptSource getConceptSourceByCode(String mappingCode) {
+		ConceptSource conceptSource = getEmrApiMetadataByCode(ConceptSource.class, mappingCode);
+		if (conceptSource == null) {
+			throw new IllegalStateException("Configuration required: " + mappingCode);
+		}
+		return conceptSource;
+	}
+	
+	protected List<PatientIdentifierType> getPatientIdentifierTypesByCode(String code) {
+		MetadataSet metadataSet = getEmrApiMetadataByCode(MetadataSet.class, code);
+		return metadataMappingService.getMetadataSetItems(PatientIdentifierType.class, metadataSet);
+	}
+	
+	protected String getEmrApiMetadataUuidByCode(String mappingCode) {
+		return getEmrApiMetadataUuidByCode(mappingCode, true);
+	}
+	
+	protected String getEmrApiMetadataUuidByCode(String mappingCode, boolean required) {
+		MetadataTermMapping mapping = metadataMappingService.getMetadataTermMapping(getEmrApiMetadataSource(), mappingCode);
+		if (mapping != null && mapping.getMetadataUuid() != null) {
+			return mapping.getMetadataUuid();
+		} else if (required) {
+			throw new IllegalStateException("Configuration required: " + mappingCode);
+		} else {
+			return null;
+		}
+	}
+	
+	protected MetadataSource getEmrApiMetadataSource() {
+		return metadataMappingService.getMetadataSourceByName(getMetadataSourceName());
+	}
+	
+	protected <T extends OpenmrsMetadata> T getEmrApiMetadataByCode(Class<T> type, String code, boolean required) {
+		T metadataItem = metadataMappingService.getMetadataItem(type, getMetadataSourceName(), code);
+		if (required && metadataItem == null) {
+			throw new IllegalStateException("Configuration required: " + code);
+		} else {
+			return metadataItem;
+		}
+	}
+	
+	protected <T extends OpenmrsMetadata> T getEmrApiMetadataByCode(Class<T> type, String code) {
+		return getEmrApiMetadataByCode(type, code, true);
+	}
+	
+	protected Concept getSingleConceptByMapping(ConceptSource conceptSource, String code) {
+		List<Concept> candidates = conceptService.getConceptsByMapping(code, conceptSource.getName(), false);
+		if (candidates.size() == 0) {
+			throw new IllegalStateException("Configuration required: can't find a concept by mapping "
+			        + conceptSource.getName() + ":" + code);
+		} else if (candidates.size() == 1) {
+			return candidates.get(0);
+		} else {
+			throw new IllegalStateException("Configuration required: found more than one concept mapped as "
+			        + conceptSource.getName() + ":" + code);
+		}
+	}
+	
+	protected Integer getIntegerByGlobalProperty(String globalPropertyName) {
+		String globalProperty = getGlobalProperty(globalPropertyName, true);
+		try {
+			return Integer.valueOf(globalProperty);
+		}
+		catch (Exception e) {
+			throw new IllegalStateException("Global property " + globalPropertyName + " value of " + globalProperty
+			        + " is not parsable as an Integer");
+		}
+	}
+	
+	protected String getGlobalProperty(String globalPropertyName, boolean required) {
+		String globalProperty = administrationService.getGlobalProperty(globalPropertyName);
+		if (required && StringUtils.isEmpty(globalProperty)) {
+			throw new IllegalStateException("Configuration required: " + globalPropertyName);
+		}
+		return globalProperty;
+	}
+	
+	protected Collection<Concept> getConceptsByGlobalProperty(String gpName) {
+		String gpValue = getGlobalProperty(gpName, false);
+		
+		if (!org.springframework.util.StringUtils.hasText(gpValue)) {
+			return Collections.emptyList();
+		}
+		
+		List<Concept> result = new ArrayList<Concept>();
+		
+		String[] concepts = gpValue.split("\\,");
+		for (String concept : concepts) {
+			Concept foundConcept = conceptService.getConceptByUuid(concept);
+			if (foundConcept == null) {
+				String[] mapping = concept.split("\\:");
+				if (mapping.length == 2) {
+					foundConcept = conceptService.getConceptByMapping(mapping[0], mapping[1]);
+				}
+			}
+			
+			if (foundConcept != null) {
+				result.add(foundConcept);
+			} else {
+				throw new IllegalStateException("Invalid configuration: concept '" + concept + "' defined in " + gpName
+				        + " does not exist");
+			}
+		}
+		
+		return result;
+	}
+}

--- a/api/src/test/java/org/openmrs/module/metadatamapping/MetadataMappingMatchers.java
+++ b/api/src/test/java/org/openmrs/module/metadatamapping/MetadataMappingMatchers.java
@@ -1,0 +1,31 @@
+package org.openmrs.module.metadatamapping;
+
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class MetadataMappingMatchers {
+	
+	public static Matcher<MetadataTermMapping> hasMappedUuid(String uuid) {
+		return new FeatureMatcher<MetadataTermMapping, String>(
+		                                                       equalTo(uuid), "metadata uuid", "metadata uuid") {
+			
+			@Override
+			protected String featureValueOf(MetadataTermMapping actual) {
+				return actual.getMetadataUuid();
+			}
+		};
+	}
+	
+	public static Matcher<MetadataTermMapping> hasMappedClass(String className) {
+		return new FeatureMatcher<MetadataTermMapping, String>(
+		                                                       equalTo(className), "metadataClass", "metadataClass") {
+			
+			@Override
+			protected String featureValueOf(MetadataTermMapping actual) {
+				return actual.getMetadataClass();
+			}
+		};
+	}
+}

--- a/api/src/test/java/org/openmrs/module/metadatamapping/util/GlobalPropertyToMappingConverterTest.java
+++ b/api/src/test/java/org/openmrs/module/metadatamapping/util/GlobalPropertyToMappingConverterTest.java
@@ -1,0 +1,111 @@
+package org.openmrs.module.metadatamapping.util;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.EncounterType;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.metadatamapping.MetadataSource;
+import org.openmrs.module.metadatamapping.MetadataTermMapping;
+import org.openmrs.module.metadatamapping.api.MetadataMappingService;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.test.Verifies;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.openmrs.module.metadatamapping.MetadataMappingMatchers.hasMappedClass;
+import static org.openmrs.module.metadatamapping.MetadataMappingMatchers.hasMappedUuid;
+
+public class GlobalPropertyToMappingConverterTest extends BaseModuleContextSensitiveTest {
+	
+	@Autowired
+	private MetadataMappingService metadataMappingService;
+	
+	private MetadataSource source;
+	
+	@Before
+	public void setup() throws Exception {
+		executeDataSet("globalPropertyToMappingConverterDataset.xml");
+		source = metadataMappingService.getMetadataSource(1);
+	}
+	
+	@Test
+	@Verifies(value = "do nothing, if mapping is not missing", method = "convert(String)")
+	public void convert_shouldDoNothingIfMappingAlreadyExists() {
+		//given
+		//test dataset
+		assertThat(metadataMappingService.getMetadataTermMapping(source, "emr.exitFromInpatientEncounterType"),
+		    is(notNullValue()));
+		
+		//when
+		getEncounterTypeConverter().convert("emr.exitFromInpatientEncounterType");
+		
+		//then
+		MetadataTermMapping termMapping = metadataMappingService.getMetadataTermMapping(source,
+		    "emr.exitFromInpatientEncounterType");
+		assertThat(termMapping, hasMappedUuid(null));
+		assertThat(termMapping, hasMappedClass("org.openmrs.EncounterType"));
+	}
+	
+	@Test
+	@Verifies(value = "create empty mapping if no global property", method = "convert(String)")
+	public void convert_shouldCreateEmptyMappingIfThereIsNoGlobalProperty() {
+		//given
+		//test dataset
+		assertThat(metadataMappingService.getMetadataTermMapping(source, "provider.exitTest"), is(nullValue()));
+		
+		//when
+		getEncounterTypeConverter().convert("emr.exitTest");
+		
+		//then
+		MetadataTermMapping termMapping = metadataMappingService.getMetadataTermMapping(source, "emr.exitTest");
+		assertThat(termMapping, hasMappedUuid(null));
+		assertThat(termMapping, hasMappedClass("org.openmrs.EncounterType"));
+	}
+	
+	@Test
+	@Verifies(value = "create empty mapping if empty global property", method = "convert(String)")
+	public void convert_shouldCreateEmptyMappingIfThereIsEmptyGlobalProperty() {
+		//given
+		//test dataset
+		assertThat(metadataMappingService.getMetadataTermMapping(source, "provider.unknownProviderUuid"), is(nullValue()));
+		
+		//when
+		getEncounterTypeConverter().convert("provider.unknownProviderUuid");
+		
+		//then
+		MetadataTermMapping termMapping = metadataMappingService.getMetadataTermMapping(source,
+		    "provider.unknownProviderUuid");
+		assertThat(termMapping, hasMappedUuid(null));
+		assertThat(termMapping, hasMappedClass("org.openmrs.EncounterType"));
+	}
+	
+	@Test
+	@Verifies(value = "map object from global property", method = "convert(String)")
+	public void convert_shouldMapObjectFromGlobalProperty() {
+		//given
+		//test dataset
+		assertThat(metadataMappingService.getMetadataTermMapping(source, "emr.checkInEncounterType"), is(nullValue()));
+		
+		//when
+		getEncounterTypeConverter().convert("emr.checkInEncounterType");
+		
+		//then
+		MetadataTermMapping termMapping = metadataMappingService.getMetadataTermMapping(source, "emr.checkInEncounterType");
+		assertThat(termMapping, hasMappedUuid("55a0d3ea-a4d7-4e88-8f01-5aceb2d3c61b"));
+		assertThat(termMapping, hasMappedClass("org.openmrs.EncounterType"));
+	}
+	
+	public GlobalPropertyToMappingConverter<EncounterType> getEncounterTypeConverter() {
+		return new GlobalPropertyToMappingConverter<EncounterType>(
+		                                                           source) {
+			
+			@Override
+			public EncounterType getMetadataByUuid(String uuid) {
+				return Context.getEncounterService().getEncounterTypeByUuid(uuid);
+			}
+		};
+	}
+}

--- a/api/src/test/java/org/openmrs/module/metadatamapping/util/ModulePropertiesComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/metadatamapping/util/ModulePropertiesComponentTest.java
@@ -1,0 +1,67 @@
+package org.openmrs.module.metadatamapping.util;
+
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.ConceptSource;
+import org.openmrs.Form;
+import org.openmrs.Location;
+import org.openmrs.Provider;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.metadatamapping.api.MetadataMappingService;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+
+public class ModulePropertiesComponentTest extends BaseModuleContextSensitiveTest {
+	
+	private ModuleProperties moduleProperties;
+	
+	@Before
+	public void setup() throws Exception {
+		executeDataSet("modulePropertiesComponentTestDataset.xml");
+		
+		moduleProperties = new ModuleProperties() {
+			
+			@Override
+			public String getMetadataSourceName() {
+				return "org.openmrs.module.emrapi";
+			}
+		};
+		
+		//module properties is manually created so services are not injected
+		moduleProperties.setAdministrationService(Context.getAdministrationService());
+		moduleProperties.setConceptService(Context.getConceptService());
+		moduleProperties.setMetadataMappingService(Context.getService(MetadataMappingService.class));
+	}
+	
+	@Test
+	public void shouldFetchConceptSourceByUuid() {
+		// this concept source is in the standard test data set
+		ConceptSource source = moduleProperties.getConceptSourceByCode("emr.someConceptSource");
+		Assert.assertNotNull(source);
+		Assert.assertEquals("Some Standardized Terminology", source.getName());
+		
+	}
+	
+	@Test
+	public void shouldFetchLocationByUuid() {
+		// this location is in the standard test data set
+		Location location = moduleProperties.getEmrApiMetadataByCode(Location.class, "emr.unknownLocation");
+		Assert.assertNotNull(location);
+		Assert.assertEquals("Unknown Location", location.getName());
+	}
+	
+	@Test
+	public void shouldFetchProviderByUuid() {
+		// this location is in the standard test data set
+		Provider provider = moduleProperties.getEmrApiMetadataByCode(Provider.class, "emr.unknownProvider");
+		Assert.assertNotNull(provider);
+		Assert.assertEquals("Test", provider.getIdentifier());
+	}
+	
+	@Test
+	public void shouldFetchFormByUuid() {
+		Form form = moduleProperties.getEmrApiMetadataByCode(Form.class, "emr.unknownForm");
+		Assert.assertNotNull(form);
+		Assert.assertEquals("Basic Form", form.getName());
+	}
+}

--- a/api/src/test/resources/globalPropertyToMappingConverterDataset.xml
+++ b/api/src/test/resources/globalPropertyToMappingConverterDataset.xml
@@ -1,0 +1,50 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<dataset>
+
+    <metadatamapping_metadata_source
+            metadata_source_id = "1"
+            creator = "1"
+            date_created="2008-08-18 12:38:58.0"
+            uuid="cf25712e-f193-48d5-a85a-5fd8d0242223"
+            name="org.openmrs.module.emrapi"
+            retired = "false"
+    />
+
+
+    <!--start emr.checkInEncounterType -> global property set, no mapping-->
+    <global_property property="emr.checkInEncounterType" property_value="55a0d3ea-a4d7-4e88-8f01-5aceb2d3c61b"
+                     uuid="6686a8c0-fcc5-4fc5-b997-906e7ee23bd1"/>
+    <encounter_type encounter_type_id="1000" name="Check-in" description="Check in for a clinic visit" creator="1"
+                    date_created="2012-10-23 18:04:14" retired="0" uuid="55a0d3ea-a4d7-4e88-8f01-5aceb2d3c61b"/>
+    <!--end emr.checkInEncounterType-->
+
+    <!--start emr.exitFromInpatientEncounterType -> global property set, mapping exists but not mapped-->
+    <metadatamapping_metadata_term_mapping metadata_term_mapping_id = "39" metadata_source_id = "1"
+                                           creator = "1" date_created="2008-08-18 12:38:58.0" uuid="453e855a-b8eb-11e2-9426-3edb8e345d35"
+                                           retired = "false" code = "emr.exitFromInpatientEncounterType" name = "emr.exitFromInpatientEncounterType"
+                                           metadata_class="org.openmrs.EncounterType"
+    />
+    <global_property property="emr.exitFromInpatientEncounterType" property_value="3bbdc54a-b8eb-11e2-9426-3edb8e345d35"
+                     uuid="453e855a-b8eb-11e2-9426-3edb8e345d35"/>
+    <encounter_type encounter_type_id="1002" name="Discharge" description="Discharge from Inpatient (allows autoclosing visits)" creator="1"
+                    date_created="2012-10-23 18:04:14" retired="0" uuid="3bbdc54a-b8eb-11e2-9426-3edb8e345d35"/>
+    <!-- end emr.exitFromInpatientEncounterType-->
+
+    <!--start provider.unknownProviderUuid -> just empty global property -->
+    <global_property property="provider.unknownProviderUuid" property_value=""
+                     uuid="984628b0-e914-11e4-b571-0800200c9a66"/>
+    <!--end provider.unknownProviderUuid -->
+
+    <!-- emr.primaryIdentifierType -> no global property, just mapping with mapped object-->
+    <metadatamapping_metadata_term_mapping metadata_term_mapping_id = "3288676" metadata_source_id = "1"
+                                           creator = "1" date_created="2008-08-18 12:38:58.0" uuid="776cb3c3-9e66-42c6-8f03-2a0c1e9ca2a8"
+                                           retired = "false" code = "emr.primaryIdentifierType" name = "emr.primaryIdentifierType"
+                                           metadata_uuid = "1a339fe9-38bc-4ab3-b180-320988c0b968" metadata_class = "org.openmrs.PatientIdentifierType"
+    />
+    <patient_identifier_type patient_identifier_type_id="1" uuid="87c67899-ae36-4535-a69f-b30ac1110c65" creator="1"
+                             date_created="2012-10-23 18:04:14" retired="0" required="false" check_digit="true"
+                             name="IDENT" description="TEST DESCRIPTION"
+    />
+
+</dataset>

--- a/api/src/test/resources/modulePropertiesComponentTestDataset.xml
+++ b/api/src/test/resources/modulePropertiesComponentTestDataset.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+    <metadatamapping_metadata_source
+            metadata_source_id = "2134" creator = "1" date_created="2008-08-18 12:38:58.0"
+            uuid="cf25712e-f193-48d5-a85a-5fd8d0242222" name="org.openmrs.module.emrapi" retired = "false"
+    />
+
+    <metadatamapping_metadata_term_mapping
+            metadata_term_mapping_id = "3245" metadata_source_id = "2134" creator = "1" date_created="2008-08-18 12:38:58.0"
+            uuid="cf25712e-f193-48d5-a85a-5fd8d0244c71" retired = "false"
+            code = "emr.unknownProvider" name = "Unknown Provider"
+            metadata_uuid = "c2299800-cca9-11e0-9572-0800200c9a66" metadata_class = "org.openmrs.Provider"
+    />
+
+    <metadatamapping_metadata_term_mapping
+            metadata_term_mapping_id = "32245" metadata_source_id = "2134" creator = "1" date_created="2008-08-18 12:38:58.0"
+            uuid="6977b3c3-9e66-42c6-8f03-2a0c1e9ca2a8" retired = "false"
+            code = "emr.unknownLocation" name = "Unknown Location"
+            metadata_uuid = "8d6c993e-c2cc-11de-8d13-0010c6dffd0f" metadata_class = "org.openmrs.Location"
+    />
+
+    <metadatamapping_metadata_term_mapping
+            metadata_term_mapping_id = "3222452" metadata_source_id = "2134" creator = "1" date_created="2008-08-18 12:38:58.0"
+            uuid="6728b3c3-9e66-42c6-8f03-2a0c1e9ca2a8" retired = "false"
+            code = "emr.unknownForm" name = "Unknown Form"
+            metadata_uuid = "d9218f76-6c39-45f4-8efa-4c5c6c199f50" metadata_class = "org.openmrs.Form"
+    />
+
+    <metadatamapping_metadata_term_mapping
+            metadata_term_mapping_id = "32224525" metadata_source_id = "2134" creator = "1" date_created="2008-08-18 12:38:58.0"
+            uuid="696cb3c3-9e66-42c6-8f03-2a0c1e9ca2a8" retired = "false"
+            code = "emr.someConceptSource" name = "Some Concept Source"
+            metadata_uuid = "00001827-639f-4cb4-961f-1e025bf80000" metadata_class = "org.openmrs.ConceptSource"
+    />
+</dataset>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
 	</modules>
 
 	<properties>
-		<openMRSVersion>1.9.8</openMRSVersion>
+		<openMRSVersion>1.9.9</openMRSVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<javaComplianceVersion>1.6</javaComplianceVersion>
 		<MODULE_ID>${project.parent.artifactId}</MODULE_ID>


### PR DESCRIPTION
Considering that most of metadata sets won't contain more than dozens of items, I think it would make sense to expose method to fetch all items from sets, like currently we are doing with MetadataSource. At the moment only method to get items from set requires to specify first result and max results. I've encountered this problem when working on https://issues.openmrs.org/browse/MAP-19.
Second commit consist of authorization control for MetadataSet management. Besides, restores MetadataMappingTerm constructor with referred object, it's way more convenient than passing class and uuid separately.
This PR is depended on by https://github.com/openmrs/openmrs-module-emrapi/pull/98